### PR TITLE
zkcli.cmd: ZOO_LOG_FILE is not set on windows

### DIFF
--- a/bin/zkCli.cmd
+++ b/bin/zkCli.cmd
@@ -17,7 +17,7 @@ REM limitations under the License.
 setlocal
 call "%~dp0zkEnv.cmd"
 
-ZOO_LOG_FILE=zookeeper-%USERNAME%-cli-%COMPUTERNAME%.log
+set ZOO_LOG_FILE=zookeeper-%USERNAME%-cli-%COMPUTERNAME%.log
 
 set ZOOMAIN=org.apache.zookeeper.ZooKeeperMain
 call %JAVA% "-Dzookeeper.log.dir=%ZOO_LOG_DIR%" "-Dzookeeper.root.logger=%ZOO_LOG4J_PROP%" "-Dzookeeper.log.file=%ZOO_LOG_FILE%" -cp "%CLASSPATH%" %ZOOMAIN% %*


### PR DESCRIPTION
using zkcli.cmd, you get 
`'ZOO_LOG_FILE' is not recognized as an internal or external command, operable program or batch file.`